### PR TITLE
Changes to support data protector push installation.

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -10,9 +10,9 @@
 		<relativePath>parent-pom.xml</relativePath>
 	</parent>
 	<groupId>${groupId}</groupId>
-	<artifactId>${artifactId}</artifactId>
+	<artifactId>${pluginName}</artifactId>
 	<version>${version}</version>
-	<name>${artifactId}</name>
+	<name>${pluginName}</name>
 	<description>${pluginName} plugin for Data Protector UIC</description>
 	<!-- Only list those additional dependencies that aren't already defined and provided by the parent (uic-plugin-parent) -->
 	<dependencies>	

--- a/src/main/resources/archetype-resources/src/assembly/distribution.xml
+++ b/src/main/resources/archetype-resources/src/assembly/distribution.xml
@@ -26,5 +26,10 @@
             <destName>${project.artifactId}.jar</destName>
             <outputDirectory>plugins</outputDirectory>
         </file>
+        <file>
+            <source>${basedir}/src/main/resources/META-INF/services/com.mf.dp.uic.plugin.spi.BackupProvider</source>
+            <destName>${project.artifactId}</destName>
+            <outputDirectory>config</outputDirectory>
+        </file>
     </files>
 </assembly>


### PR DESCRIPTION
We are enhancing data protector push installation to support pushing unified plugins to clients.
These changes are needed:
To identify plugin name through final tar.gz file.
To avoid manual configuration of properties file in all the clients.